### PR TITLE
Reenabled replay, updated to current golang http2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# http2fuzz (No longer under development)
+# http2fuzz 
 
 HTTP2 fuzzer built in Golang.
 
@@ -124,45 +124,23 @@ fuzzer/connection.go conatins the Connection struct. This structure sits on top 
 fuzzer/fuzzer.go contains all the fuzzing strategies.
 
 ## Replay Mode
+Running in replay mode:
+./http2fuzz -target "TTT.XXX.YYY.ZZZ:443" -replay
 
-The code recently got refactored and it hasen't been refactoed back in, and it only works with raw frames fuzzer, for testing with single frames, a script like this works:
+Will replay the HTTP2 requests logged in replay.json at a rate of 1 per second.
 
-```
-package main
+This function currently only works when http2fuzz is running as the client. Extending this functionality to server mode is the main goal for the next release.
 
-import (
-    "io"
-    "net"
 
-    "github.com/bradfitz/http2"
-    "github.com/c0nrad/http2fuzz/util"
-)
-
-func main() {
-    var Target = "localhost:80"
-
-    conn := Dial(Target)
-    io.WriteString(conn, http2.ClientPreface)
-
-    framer := http2.NewFramer(conn, conn)
-
-    // FrameType, Flag, StreamId, Payload
-    framer.WriteRawFrame(http2.FrameType(10), http2.Flags(16), 481004859, util.FromBase64("dZfden+U2nU/Y5uUsM3iz2XwAboFueI/xyR2"))
-}
-
-func Dial(host string) net.Conn {
-    conn, err := net.Dial("tcp", host)
-    if err != nil {
-        panic(err)
-    }
-    return conn
-}
-```
+**WARNING**
+If you run http2fuzz _not_ in replay mode it will overwrite your replay.json file. I will fix this in the next update.
 
 ## Contact
 
 stuartlarsen@yahoo-inc.com
+current version: jmpalk@gmail.com
 
 ## Copyright
 
 Copyright 2015 Yahoo Inc. Licensed under the BSD license, see LICENSE file for terms. Written by Stuart Larsen
+Modified by Justin Palk

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@
 // Licensed under the BSD license, see LICENSE file for terms.
 // Written by Stuart Larsen
 // http2fuzz - HTTP/2 Fuzzer
+// Modified by Justin Palk
 package config
 
 import (
@@ -42,7 +43,8 @@ func init() {
 	flag.StringVar(&Port, "port", "8000", "port to listen from")
 	flag.StringVar(&Interface, "listen", "0.0.0.0", "interface to listen from")
 
-	// flag.BoolVar(&ReplayMode, "replay", false, "replay frames from replay.json")
+	//line below was originally commented out
+	flag.BoolVar(&ReplayMode, "replay", false, "replay frames from replay.json")
 	flag.Parse()
 
 	RestartDelay = time.Duration(restartMillisecond) * time.Millisecond

--- a/fuzzer/client.go
+++ b/fuzzer/client.go
@@ -2,9 +2,19 @@
 // Licensed under the BSD license, see LICENSE file for terms.
 // Written by Stuart Larsen
 // http2fuzz - HTTP/2 Fuzzer
+// Modified by Justin Palk
 package fuzzer
 
-import "github.com/c0nrad/http2fuzz/config"
+
+import (
+	"fmt"
+	"time"
+	"os"
+	"golang.org/x/net/http2"
+	"github.com/jmpalk/http2fuzz/config"
+	"github.com/jmpalk/http2fuzz/util"
+	"github.com/jmpalk/http2fuzz/replay"
+)
 
 func Client() {
 	target := config.Target
@@ -12,7 +22,19 @@ func Client() {
 	restartFuzzer := true
 	sendSettingsInit := true
 
+	//added JMP 4-22-16
+	replayMode := config.ReplayMode
+
 	conn0 := NewConnection(target, tls, true, sendSettingsInit)
+
+	if replayMode != false {
+		var frames []string
+		frames = replay.ReadFromReplayFile()
+		RunReplay(conn0, frames)
+		os.Exit(0)
+	}
+
+
 	fuzzer0 := NewFuzzer(conn0, restartFuzzer)
 	go fuzzer0.PingFuzzer()
 
@@ -81,3 +103,92 @@ func Client() {
 	go fuzzer12.ContinuationFuzzer()
 	go fuzzer12.WindowUpdateFuzzer()
 }
+
+func RunReplay(c *Connection, frames []string) {
+	for _, frameJSON := range frames {
+ 		frame := util.FromJSON([]byte(frameJSON))
+
+ 		if c.Err != nil {
+ 			fmt.Println("Connection Error", c.Err, "restarting connection")
+ 			c = NewConnection(config.Target, c.IsTLS, c.IsPreface, c.IsSendSettings)
+ 		}
+
+ 		switch frame["FrameMethod"] {
+ 		case "RawFrame":
+ 			fmt.Println(frame)
+ 			frameType := uint8(frame["FrameType"].(float64))
+ 			flags := uint8(frame["Flags"].(float64))
+ 			streamID := uint32(frame["StreamID"].(float64))
+ 			payload := util.FromBase64(frame["Payload"].(string))
+ 			c.WriteRawFrame(frameType, flags, streamID, payload)
+ 			time.Sleep(time.Second * 1)
+		case "WindowUpdateFrame":
+			fmt.Println(frame)
+ 			streamID := uint32(frame["StreamID"].(float64))
+			incr := uint32(frame["Incr"].(float64))
+			c.WriteWindowUpdateFrame(streamID, incr)
+			time.Sleep(time.Second * 1)
+		case "ResetFrame":
+			fmt.Println(frame)
+ 			streamID := uint32(frame["StreamID"].(float64))
+ 			errorCode := uint32(frame["ErrorCode"].(float64))
+			c.WriteResetFrame(streamID, errorCode)
+			time.Sleep(time.Second * 1)
+		case "PriorityFrame":
+			fmt.Println(frame)
+ 			streamID := uint32(frame["StreamID"].(float64))
+ 			streamDep := uint32(frame["StreamDep"].(float64))
+			weight := uint8(frame["Weight"].(float64))
+			exclusive := bool(frame["Exclusive"].(bool))
+			c.WritePriorityFrame(streamID, streamDep, weight, exclusive)
+			time.Sleep(time.Second * 1)
+		case "WriteContinuationFrame":
+			fmt.Println(frame)
+ 			streamID := uint32(frame["StreamID"].(float64))
+			endStream := bool(frame["EndStream"].(bool))
+ 			data := util.FromBase64(frame["Data"].(string))
+			c.WriteContinuationFrame(streamID, endStream, data)
+			time.Sleep(time.Second * 1)
+		case "PushPromiseFrame":
+			fmt.Println(frame)
+ 			streamID := uint32(frame["StreamID"].(float64))
+ 			promiseID := uint32(frame["PromiseID"].(float64))
+ 			blockFragment := util.FromBase64(frame["BlockFragment"].(string))
+			endHeaders := bool(frame["EndHeaders"].(bool))
+			padLength := uint8(frame["PadLength"].(float64))
+			promise := http2.PushPromiseParam{streamID, promiseID, blockFragment, endHeaders, padLength}
+			c.WritePushPromiseFrame(promise)
+			time.Sleep(time.Second * 1)
+		case "DataFrame":
+			fmt.Println(frame)
+ 			streamID := uint32(frame["StreamID"].(float64))
+			endStream := bool(frame["EndStream"].(bool))
+			data := util.FromBase64(frame["Data"].(string))
+			c.WriteDataFrame(streamID, endStream, data)
+			time.Sleep(time.Second * 1)
+		case "SettingsFrame":
+			var settings []http2.Setting
+
+			m := frame["Settings"].([]interface{})
+			for _, v := range m{
+				switch vv := v.(type) {
+					case map[string]interface{}:
+						var ID uint16
+						var Value uint32
+						for i, u := range vv {
+							if string(i) == "ID" {
+								ID = uint16(u.(float64))
+							} else if string(i) == "Val" {
+								Value = uint32(u.(float64))
+							}
+						}
+						settings = append(settings, http2.Setting{http2.SettingID(ID), Value})
+					}
+				}
+			c.WriteSettingsFrame(settings)
+			time.Sleep(time.Second * 1)
+
+ 		}
+ 	}
+ 	fmt.Println("ALL DONE")
+ }

--- a/fuzzer/fuzzer.go
+++ b/fuzzer/fuzzer.go
@@ -2,6 +2,7 @@
 // Licensed under the BSD license, see LICENSE file for terms.
 // Written by Stuart Larsen
 // http2fuzz - HTTP/2 Fuzzer
+// Modified by Justin Palk
 package fuzzer
 
 import (
@@ -12,10 +13,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/c0nrad/http2fuzz/config"
-	"github.com/c0nrad/http2fuzz/util"
+	"github.com/jmpalk/http2fuzz/config"
+	"github.com/jmpalk/http2fuzz/util"
 
-	"github.com/bradfitz/http2"
+	"golang.org/x/net/http2"
 )
 
 type Fuzzer struct {

--- a/fuzzer/server.go
+++ b/fuzzer/server.go
@@ -2,6 +2,7 @@
 // Licensed under the BSD license, see LICENSE file for terms.
 // Written by Stuart Larsen
 // http2fuzz - HTTP/2 Fuzzer
+// Modified by Justin Palk
 package fuzzer
 
 import (
@@ -10,8 +11,8 @@ import (
 	"log"
 	"net"
 
-	"github.com/c0nrad/http2fuzz/config"
-	"github.com/c0nrad/http2fuzz/replay"
+	"github.com/jmpalk/http2fuzz/config"
+	"github.com/jmpalk/http2fuzz/replay"
 )
 
 func FuzzConnection(conn net.Conn) {

--- a/main.go
+++ b/main.go
@@ -4,8 +4,8 @@ import (
 	"flag"
 	"os"
 
-	"github.com/c0nrad/http2fuzz/config"
-	"github.com/c0nrad/http2fuzz/fuzzer"
+	"github.com/jmpalk/http2fuzz/config"
+	"github.com/jmpalk/http2fuzz/fuzzer"
 )
 
 func main() {

--- a/util/util.go
+++ b/util/util.go
@@ -1,3 +1,8 @@
+// Copyright 2015 Yahoo Inc.
+// Licensed under the BSD license, see LICENSE file for terms.
+// Written by Stuart Larsen
+// http2fuzz - HTTP/2 Fuzzer
+// Modified by Justin Palk
 package util
 
 import (
@@ -13,7 +18,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bradfitz/http2"
+	"golang.org/x/net/http2"
 )
 
 func FromBase64(in string) []byte {


### PR DESCRIPTION
Reenabled replay mode for http2fuzz running as a client.
Updated to use golang.org/x/net/http2 rather than bradfitz/http2
